### PR TITLE
Use LLM to review the text against editorial guidelines. (vibe-kanban)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
 PORT=3000
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
 # babel-bot
+
+A TypeScript API for translating media articles with editorial guidelines review using Anthropic's Claude LLM.
+
+## Features
+
+- Translation service with LLM-powered editorial review
+- Uses Anthropic's Claude API for intelligent text analysis
+- Comprehensive editorial guidelines compliance checking
+- RESTful API with Express.js
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Copy the environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Add your Anthropic API key to `.env`:
+   ```
+   ANTHROPIC_API_KEY=your_actual_api_key_here
+   ```
+
+4. Build the project:
+   ```bash
+   npm run build
+   ```
+
+5. Start the server:
+   ```bash
+   npm start
+   ```
+
+## API Endpoints
+
+### POST /api/translate
+
+Reviews and translates media articles against editorial guidelines using Claude LLM.
+
+**Request Body:**
+```json
+{
+  "mediaArticle": {
+    "text": "Your article text here",
+    "title": "Article Title"
+  },
+  "editorialGuidelines": {
+    "tone": "professional",
+    "style": "journalistic",
+    "targetAudience": "general public",
+    "restrictions": ["no technical jargon"],
+    "requirements": ["maintain engaging tone"]
+  },
+  "destinationLanguages": ["es", "fr", "de"]
+}
+```
+
+**Response:**
+```json
+{
+  "originalArticle": { ... },
+  "translations": [
+    {
+      "language": "es",
+      "translatedText": "...",
+      "reviewNotes": ["LLM-generated review comments"],
+      "complianceScore": 95.2
+    }
+  ],
+  "processedAt": "2025-01-01T00:00:00.000Z"
+}
+```
+
+### GET /api/health
+
+Health check endpoint.
+
+## Development
+
+- `npm run dev` - Start development server with hot reload
+- `npm run build` - Build TypeScript to JavaScript
+- `npm run typecheck` - Run TypeScript type checking

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.57.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -38,6 +39,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.57.0.tgz",
+      "integrity": "sha512-z5LMy0MWu0+w2hflUgj4RlJr1R+0BxKXL7ldXTO8FasU8fu599STghO+QKwId2dAD0d464aHtU+ChWuRHw4FNw==",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -11,25 +11,31 @@
     "lint": "eslint src/**/*.ts",
     "typecheck": "tsc --noEmit"
   },
-  "keywords": ["translation", "api", "typescript", "media"],
+  "keywords": [
+    "translation",
+    "api",
+    "typescript",
+    "media"
+  ],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2",
+    "@anthropic-ai/sdk": "^0.57.0",
     "cors": "^2.8.5",
-    "helmet": "^7.1.0",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.1.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
     "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.8",
     "@types/node": "^20.10.5",
-    "typescript": "^5.3.3",
-    "ts-node": "^10.9.2",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
-    "@types/jest": "^29.5.8"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -1,6 +1,14 @@
 import { MediaArticle, EditorialGuidelines, TranslationResult } from '../types';
+import Anthropic from '@anthropic-ai/sdk';
 
 export class TranslationService {
+  private anthropic: Anthropic;
+
+  constructor() {
+    this.anthropic = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    });
+  }
   async translateArticle(
     article: MediaArticle,
     guidelines: EditorialGuidelines,
@@ -10,7 +18,7 @@ export class TranslationService {
 
     for (const language of destinationLanguages) {
       const translatedText = await this.performTranslation(article.text, language);
-      const reviewNotes = this.reviewAgainstGuidelines(translatedText, guidelines);
+      const reviewNotes = await this.reviewAgainstGuidelines(translatedText, guidelines);
       const complianceScore = this.calculateComplianceScore(reviewNotes);
 
       results.push({
@@ -28,29 +36,70 @@ export class TranslationService {
     return `[TRANSLATED TO ${language.toUpperCase()}] ${text}`;
   }
 
-  private reviewAgainstGuidelines(
+  private async reviewAgainstGuidelines(
     translatedText: string,
     guidelines: EditorialGuidelines
-  ): string[] {
-    const notes: string[] = [];
+  ): Promise<string[]> {
+    try {
+      const prompt = this.buildReviewPrompt(translatedText, guidelines);
+      
+      const response = await this.anthropic.messages.create({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: prompt }],
+      });
+
+      const reviewText = response.content[0].type === 'text' ? response.content[0].text : '';
+      return this.parseReviewResponse(reviewText);
+    } catch (error) {
+      console.error('LLM review error:', error);
+      return [`Review failed: ${error instanceof Error ? error.message : 'Unknown error'}`];
+    }
+  }
+
+  private buildReviewPrompt(text: string, guidelines: EditorialGuidelines): string {
+    let prompt = `Please review the following text against the editorial guidelines provided. Provide specific feedback on compliance and areas for improvement.
+
+Text to review:
+"${text}"
+
+Editorial Guidelines:`;
 
     if (guidelines.tone) {
-      notes.push(`Tone compliance: Verified against ${guidelines.tone} tone`);
+      prompt += `\n- Tone: ${guidelines.tone}`;
     }
-
     if (guidelines.style) {
-      notes.push(`Style compliance: Verified against ${guidelines.style} style`);
+      prompt += `\n- Style: ${guidelines.style}`;
     }
-
     if (guidelines.targetAudience) {
-      notes.push(`Audience alignment: Verified for ${guidelines.targetAudience}`);
+      prompt += `\n- Target Audience: ${guidelines.targetAudience}`;
     }
-
     if (guidelines.restrictions && guidelines.restrictions.length > 0) {
-      notes.push(`Restrictions checked: ${guidelines.restrictions.join(', ')}`);
+      prompt += `\n- Restrictions: ${guidelines.restrictions.join(', ')}`;
+    }
+    if (guidelines.requirements && guidelines.requirements.length > 0) {
+      prompt += `\n- Requirements: ${guidelines.requirements.join(', ')}`;
     }
 
-    return notes;
+    prompt += `\n\nPlease provide your review as a numbered list of specific observations, each on a new line starting with a number and period (e.g., "1. The tone is...").`;
+
+    return prompt;
+  }
+
+  private parseReviewResponse(reviewText: string): string[] {
+    const lines = reviewText.split('\n').filter(line => line.trim());
+    const notes: string[] = [];
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.match(/^\d+\./)) {
+        notes.push(trimmed.replace(/^\d+\.\s*/, ''));
+      } else if (trimmed && !trimmed.match(/^(please|here|the following)/i)) {
+        notes.push(trimmed);
+      }
+    }
+
+    return notes.length > 0 ? notes : ['Review completed successfully'];
   }
 
   private calculateComplianceScore(reviewNotes: string[]): number {


### PR DESCRIPTION
Use an LLM to review the text against the editorial guidelines. Use the Anthropic API with a claude model. The typescript SDK is here at this repo url if you need extra references: https://github.com/anthropics/anthropic-sdk-typescript

Here are some example snippets:

import Anthropic from '@anthropic-ai/sdk';

const anthropic = new Anthropic({
  apiKey: 'my_api_key', // defaults to process.env["ANTHROPIC_API_KEY"]
});

const msg = await anthropic.messages.create({
  model: "claude-sonnet-4-20250514",
  max_tokens: 1024,
  messages: [{ role: "user", content: "Hello, Claude" }],
});
console.log(msg);

// Claude 4 Models
"claude-opus-4-20250514"
"claude-opus-4-0"  // alias
"claude-sonnet-4-20250514"
"claude-sonnet-4-0"  // alias

// Claude 3.7 Models
"claude-3-7-sonnet-20250219"
"claude-3-7-sonnet-latest"  // alias

// Claude 3.5 Models
"claude-3-5-haiku-20241022"
"claude-3-5-haiku-latest"  // alias
"claude-3-5-sonnet-20241022"
"claude-3-5-sonnet-latest"  // alias
"claude-3-5-sonnet-20240620"  // previous version

// Claude 3 Models
"claude-3-opus-20240229"
"claude-3-opus-latest"  // alias
"claude-3-sonnet-20240229"
"claude-3-haiku-20240307"