### PR TITLE
Improve the `guide` param functionality (vibe-kanban)

### DIFF
--- a/src/database/dbService.ts
+++ b/src/database/dbService.ts
@@ -23,6 +23,7 @@ export interface TranslationTask {
   updatedAt: string;
   progress?: number;
   guide?: GuideType;
+  useFullMarkdown?: boolean;
 }
 
 export class DatabaseService {

--- a/src/routes/translation.ts
+++ b/src/routes/translation.ts
@@ -16,6 +16,7 @@ router.post("/translate", async (req: Request, res: Response) => {
       editorialGuidelines,
       destinationLanguages,
       guide,
+      useFullMarkdown,
     }: TranslationRequest = req.body;
 
     if (!mediaArticle || !mediaArticle.text) {
@@ -41,7 +42,8 @@ router.post("/translate", async (req: Request, res: Response) => {
       mediaArticle,
       editorialGuidelines || {},
       destinationLanguages,
-      guide
+      guide,
+      useFullMarkdown
     );
 
     res.json({

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -23,7 +23,8 @@ export class TaskService {
     mediaArticle: MediaArticle,
     editorialGuidelines: EditorialGuidelines,
     destinationLanguages: string[],
-    guide?: GuideType
+    guide?: GuideType,
+    useFullMarkdown?: boolean
   ): Promise<string> {
     const taskId = await this.dbService.createTask({
       status: "pending",
@@ -32,6 +33,7 @@ export class TaskService {
       destinationLanguages,
       progress: 0,
       guide,
+      useFullMarkdown,
     });
 
     this.processTaskAsync(taskId);
@@ -56,7 +58,8 @@ export class TaskService {
         task.mediaArticle,
         task.editorialGuidelines,
         task.destinationLanguages,
-        task.guide
+        task.guide,
+        task.useFullMarkdown
       );
 
       await this.dbService.updateTask(taskId, {

--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -34,20 +34,23 @@ export class TranslationService {
     article: MediaArticle,
     guidelines: EditorialGuidelines,
     destinationLanguages: string[],
-    guide?: GuideType
+    guide?: GuideType,
+    useFullMarkdown?: boolean
   ): Promise<TranslationResult[]> {
     const results: TranslationResult[] = [];
     this.setup();
 
-    const effectiveGuidelines = await this.loadGuidelinesByType(
+    const { effectiveGuidelines, contextText } = await this.loadGuidelinesByType(
       guide || "financialtimes",
-      guidelines
+      guidelines,
+      useFullMarkdown
     );
 
     for (const language of destinationLanguages) {
       const translatedText = await this.performTranslation(
         article.text,
-        language
+        language,
+        contextText
       );
       const reviewResult = await this.reviewService.reviewAgainstGuidelines(
         translatedText,
@@ -68,24 +71,89 @@ export class TranslationService {
 
   private async loadGuidelinesByType(
     guide: GuideType,
-    fallbackGuidelines: EditorialGuidelines
-  ): Promise<EditorialGuidelines> {
+    fallbackGuidelines: EditorialGuidelines,
+    useFullMarkdown?: boolean
+  ): Promise<{ effectiveGuidelines: EditorialGuidelines; contextText: string }> {
     try {
+      const fileExtension = useFullMarkdown ? "md" : "txt";
       const guidelinePath = path.join(
         process.cwd(),
         "editorial",
         "guidelines",
-        `${guide}.md`
+        `${guide}.${fileExtension}`
       );
-      const markdownContent = fs.readFileSync(guidelinePath, "utf-8");
+      
+      let fileContent: string;
+      try {
+        fileContent = fs.readFileSync(guidelinePath, "utf-8");
+      } catch (error) {
+        const fallbackExtension = useFullMarkdown ? "txt" : "md";
+        const fallbackPath = path.join(
+          process.cwd(),
+          "editorial",
+          "guidelines",
+          `${guide}.${fallbackExtension}`
+        );
+        fileContent = fs.readFileSync(fallbackPath, "utf-8");
+      }
 
-      return this.parseMarkdownGuidelines(markdownContent, fallbackGuidelines);
+      let effectiveGuidelines: EditorialGuidelines;
+      if (useFullMarkdown) {
+        effectiveGuidelines = this.parseMarkdownGuidelines(fileContent, fallbackGuidelines);
+      } else {
+        effectiveGuidelines = { ...fallbackGuidelines };
+      }
+
+      let contextText = fileContent;
+      
+      const hasOverrides = Object.keys(fallbackGuidelines).some(
+        key => fallbackGuidelines[key as keyof EditorialGuidelines] !== undefined
+      );
+      
+      if (hasOverrides) {
+        contextText += "\n\n--- EDITORIAL OVERRIDES ---\n\n";
+        if (fallbackGuidelines.tone) {
+          contextText += `Tone Override: ${fallbackGuidelines.tone}\n`;
+        }
+        if (fallbackGuidelines.style) {
+          contextText += `Style Override: ${fallbackGuidelines.style}\n`;
+        }
+        if (fallbackGuidelines.targetAudience) {
+          contextText += `Target Audience Override: ${fallbackGuidelines.targetAudience}\n`;
+        }
+        if (fallbackGuidelines.restrictions?.length) {
+          contextText += `Restrictions Override: ${fallbackGuidelines.restrictions.join(", ")}\n`;
+        }
+        if (fallbackGuidelines.requirements?.length) {
+          contextText += `Requirements Override: ${fallbackGuidelines.requirements.join(", ")}\n`;
+        }
+      }
+
+      return { effectiveGuidelines, contextText };
     } catch (error) {
       console.warn(
         `Could not load guidelines for ${guide}, using fallback:`,
         error
       );
-      return fallbackGuidelines;
+      
+      let contextText = "Using fallback editorial guidelines.\n\n";
+      if (fallbackGuidelines.tone) {
+        contextText += `Tone: ${fallbackGuidelines.tone}\n`;
+      }
+      if (fallbackGuidelines.style) {
+        contextText += `Style: ${fallbackGuidelines.style}\n`;
+      }
+      if (fallbackGuidelines.targetAudience) {
+        contextText += `Target Audience: ${fallbackGuidelines.targetAudience}\n`;
+      }
+      if (fallbackGuidelines.restrictions?.length) {
+        contextText += `Restrictions: ${fallbackGuidelines.restrictions.join(", ")}\n`;
+      }
+      if (fallbackGuidelines.requirements?.length) {
+        contextText += `Requirements: ${fallbackGuidelines.requirements.join(", ")}\n`;
+      }
+      
+      return { effectiveGuidelines: fallbackGuidelines, contextText };
     }
   }
 
@@ -141,7 +209,8 @@ export class TranslationService {
 
   private async performTranslation(
     text: string,
-    language: string
+    language: string,
+    context?: string
   ): Promise<string> {
     const isDemoMode = process.env.DEMO_MODE === "true";
 
@@ -151,10 +220,15 @@ export class TranslationService {
     }
 
     try {
+      const translateOptions: any = {
+        context: context || undefined
+      };
+      
       const result = await this.translator?.translateText(
         text,
         null,
-        language as deepl.TargetLanguageCode
+        language as deepl.TargetLanguageCode,
+        translateOptions
       );
       return result?.text || "";
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface TranslationRequest {
   editorialGuidelines: EditorialGuidelines;
   destinationLanguages: string[];
   guide?: GuideType;
+  useFullMarkdown?: boolean;
 }
 
 export type LanguageTaskStatus = 'pending' | 'translating' | 'llm_verification' | 'human_review' | 'done' | 'failed';
@@ -44,6 +45,7 @@ export interface TranslationTask {
   editorialGuidelines: EditorialGuidelines;
   destinationLanguages: string[];
   guide?: GuideType;
+  useFullMarkdown?: boolean;
   result?: TranslationResponse;
   error?: string;
   createdAt: string;


### PR DESCRIPTION
Let's amend the guide param functionality a bit. Let's add a new optional param that enables sending the full markdown guideline file for context. Otherwise by default we'll use a more concise .txt file which is more llm friendly and will consume less context window. The naming of the files is the same, so prolific.md is the longer form and prolific.txt is the shorter (default) form.

Additionally, let's fix how the guideline files content is handled. We want to make sure the WHOLE file is passed to the DeepL translate call as `context`. Then the rest of the `editorialGuidelines` object (the overrides) should be added to the bottom of the `context` text and clearly marked as overrides.