### PR TITLE
Improve the reviewAgainstGuidelines process (vibe-kanban)

### DIFF
--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -27,7 +27,8 @@ export class ReviewService {
 
   async reviewAgainstGuidelines(
     translatedText: string,
-    guidelines: EditorialGuidelines
+    guidelines: EditorialGuidelines,
+    fullContextText?: string
   ): Promise<{ notes: string[]; score: number }> {
     const isDemoMode = process.env.DEMO_MODE === "true";
 
@@ -45,7 +46,7 @@ export class ReviewService {
     }
 
     try {
-      const prompt = this.buildReviewPrompt(translatedText, guidelines);
+      const prompt = this.buildReviewPrompt(translatedText, guidelines, fullContextText);
       console.log("Prompt:", prompt);
       console.log("Anthropic:", this.anthropic);
 
@@ -74,29 +75,34 @@ export class ReviewService {
 
   private buildReviewPrompt(
     text: string,
-    guidelines: EditorialGuidelines
+    guidelines: EditorialGuidelines,
+    fullContextText?: string
   ): string {
-    let prompt = `Please review the following text against the editorial guidelines provided. Provide specific feedback on compliance and areas for improvement.
+    let prompt = `Please review the following translated text against the editorial guidelines provided. Provide specific feedback on compliance and areas for improvement.
 
 Text to review:
 "${text}"
 
 Editorial Guidelines:`;
 
-    if (guidelines.tone) {
-      prompt += `\n- Tone: ${guidelines.tone}`;
-    }
-    if (guidelines.style) {
-      prompt += `\n- Style: ${guidelines.style}`;
-    }
-    if (guidelines.targetAudience) {
-      prompt += `\n- Target Audience: ${guidelines.targetAudience}`;
-    }
-    if (guidelines.restrictions && guidelines.restrictions.length > 0) {
-      prompt += `\n- Restrictions: ${guidelines.restrictions.join(", ")}`;
-    }
-    if (guidelines.requirements && guidelines.requirements.length > 0) {
-      prompt += `\n- Requirements: ${guidelines.requirements.join(", ")}`;
+    if (fullContextText) {
+      prompt += `\n\n${fullContextText}`;
+    } else {
+      if (guidelines.tone) {
+        prompt += `\n- Tone: ${guidelines.tone}`;
+      }
+      if (guidelines.style) {
+        prompt += `\n- Style: ${guidelines.style}`;
+      }
+      if (guidelines.targetAudience) {
+        prompt += `\n- Target Audience: ${guidelines.targetAudience}`;
+      }
+      if (guidelines.restrictions && guidelines.restrictions.length > 0) {
+        prompt += `\n- Restrictions: ${guidelines.restrictions.join(", ")}`;
+      }
+      if (guidelines.requirements && guidelines.requirements.length > 0) {
+        prompt += `\n- Requirements: ${guidelines.requirements.join(", ")}`;
+      }
     }
 
     prompt += `\n\nPlease provide your review as a numbered list of specific observations, each on a new line starting with a number and period (e.g., "1. The tone is...").

--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -54,7 +54,8 @@ export class TranslationService {
       );
       const reviewResult = await this.reviewService.reviewAgainstGuidelines(
         translatedText,
-        effectiveGuidelines
+        effectiveGuidelines,
+        contextText
       );
       const complianceScore = reviewResult.score;
 


### PR DESCRIPTION
As part of the flow, the system reviews the translated text against the guidelines with a call to claude. Right now these guidelines are provided to claude very poorly and don't match what we've provided to deepl. Let's make sure this review process matches properly with full context provided from the file as well as providing the overrides as it currently does.