### PR TITLE
Fix the split task logic (vibe-kanban)

### DIFF
--- a/src/client/components/TaskCard.tsx
+++ b/src/client/components/TaskCard.tsx
@@ -18,12 +18,17 @@ import { getLanguageDisplayName } from '../../utils/languageUtils';
 interface TaskCardProps {
   task: TranslationTask;
   onClick: () => void;
+  filteredLanguages?: string[];
+  isPartialDisplay?: boolean;
+  currentColumnStatus?: LanguageTaskStatus;
 }
 
-const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
+const TaskCard: React.FC<TaskCardProps> = ({ task, onClick, filteredLanguages, isPartialDisplay = false, currentColumnStatus }) => {
+
+  const displayStatus = currentColumnStatus || task.status;
 
   const getStatusIcon = () => {
-    switch (task.status) {
+    switch (displayStatus) {
       case 'failed':
         return <ErrorIcon color="error" fontSize="small" />;
       case 'translating':
@@ -55,9 +60,10 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
 
   const languageStates = getLanguageStatesForTask(task);
   const hasSplitStates = hasMultipleLanguageStates(task);
+  const displayLanguages = filteredLanguages || task.destinationLanguages;
 
   const getStatusGradient = () => {
-    switch (task.status) {
+    switch (displayStatus) {
       case 'pending':
         return 'linear-gradient(135deg, #ef4444 0%, #f87171 100%)';
       case 'translating':
@@ -133,9 +139,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
             }}
           >
             {task.id.split('_')[1]}
-            {hasSplitStates && (
+            {isPartialDisplay && (
               <Chip
-                label="SPLIT"
+                label="PARTIAL"
                 size="small"
                 sx={{
                   ml: 1,
@@ -177,25 +183,26 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
         >
           {task.mediaArticle.title || task.mediaArticle.text.substring(0, 60) + '...'}
         </Typography>
-        {task.result && (
+        {task.result && isPartialDisplay && (
             <Box sx={{ mt: 1 }}>
               <Typography variant="caption" sx={{ display: 'block', mb: 1 }}>
-                <strong>Translations:</strong> {task.result.translations.length}
+                <strong>Languages in {displayStatus}:</strong> {displayLanguages.length}
               </Typography>
-              {hasSplitStates && (
-                <Box sx={{ mt: 1 }}>
-                  {task.result.translations.map((translation, index) => (
+              <Box sx={{ mt: 1 }}>
+                {task.result.translations
+                  .filter(translation => displayLanguages.includes(translation.language))
+                  .map((translation, index) => (
                     <Box key={index} sx={{ mb: 1, p: 1, backgroundColor: '#f8f9fa', borderRadius: 1 }}>
                       <Typography variant="caption" sx={{ display: 'block' }}>
                         <strong>{getLanguageDisplayName(translation.language)}:</strong>
                         <Chip
-                          label={translation.status || 'done'}
+                          label={translation.status || displayStatus}
                           size="small"
                           sx={{
                             ml: 1,
                             height: 16,
                             fontSize: '0.6rem',
-                            backgroundColor: getLanguageStatusColor(translation.status || 'done'),
+                            backgroundColor: getLanguageStatusColor(translation.status || displayStatus),
                             color: 'white',
                           }}
                         />
@@ -207,24 +214,30 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
                       )}
                     </Box>
                   ))}
-                </Box>
-              )}
+              </Box>
+            </Box>
+          )}
+          {task.result && !isPartialDisplay && (
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="caption" sx={{ display: 'block', mb: 1 }}>
+                <strong>Translations:</strong> {task.result.translations.length}
+              </Typography>
             </Box>
           )}
         
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1 }}>
-          {task.destinationLanguages.slice(0, 3).map(lang => {
-            const langStatus = languageStates.get(lang) || 'pending';
+          {displayLanguages.slice(0, 3).map(lang => {
+            const langStatus = languageStates.get(lang) || displayStatus;
             const statusColor = getLanguageStatusColor(langStatus);
             return (
               <Chip
                 key={lang}
                 label={getLanguageDisplayName(lang)}
                 size="small"
-                variant={hasSplitStates ? "filled" : "outlined"}
+                variant={isPartialDisplay ? "filled" : "outlined"}
                 sx={{ 
                   fontSize: '0.7rem',
-                  ...(hasSplitStates && {
+                  ...(isPartialDisplay && {
                     backgroundColor: statusColor,
                     color: 'white',
                     '&:hover': {
@@ -236,9 +249,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
               />
             );
           })}
-          {task.destinationLanguages.length > 3 && (
+          {displayLanguages.length > 3 && (
             <Chip
-              label={`+${task.destinationLanguages.length - 3}`}
+              label={`+${displayLanguages.length - 3}`}
               size="small"
               sx={{ 
                 fontSize: '0.7rem',
@@ -250,7 +263,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onClick }) => {
           )}
         </Box>
 
-        {(task.status === 'translating' || task.status === 'llm_verification' || task.status === 'human_review') && (
+        {(displayStatus === 'translating' || displayStatus === 'llm_verification' || displayStatus === 'human_review') && (
           <Box sx={{ mb: 2 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
               <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600 }}>

--- a/src/client/components/TaskDetailsModal.tsx
+++ b/src/client/components/TaskDetailsModal.tsx
@@ -40,7 +40,7 @@ import {
   Star as StarIcon,
   StarBorder as StarBorderIcon,
 } from '@mui/icons-material';
-import { TranslationTask, LanguageTaskStatus } from '../../types';
+import { TranslationTask, LanguageTaskStatus, getLanguageStatesForTask } from '../../types';
 import { getLanguageDisplayName } from '../../utils/languageUtils';
 import TranslationTimeline from './TranslationTimeline';
 
@@ -406,23 +406,68 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({ task, open, onClose
                     <Typography variant="h6" sx={{ color: '#1e293b', fontWeight: 600, mb: 2 }}>
                       Target Languages
                     </Typography>
-                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                      {task.destinationLanguages.map(lang => (
-                        <Chip
-                          key={lang}
-                          label={getLanguageDisplayName(lang)}
-                          sx={{ 
-                            fontSize: '0.875rem',
-                            fontWeight: 600,
-                            background: getStatusGradient(),
-                            color: 'white',
-                            '&:hover': {
-                              transform: 'scale(1.05)',
-                            },
-                            transition: 'transform 0.2s ease',
-                          }}
-                        />
-                      ))}
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                      {task.destinationLanguages.map(lang => {
+                        const languageStates = getLanguageStatesForTask(task);
+                        const langStatus = languageStates.get(lang) || 'pending';
+                        const isFailedLang = langStatus === 'failed';
+                        
+                        const getLanguageStatusGradient = (status: LanguageTaskStatus) => {
+                          switch (status) {
+                            case 'pending':
+                              return 'linear-gradient(135deg, #ef4444 0%, #f87171 100%)';
+                            case 'translating':
+                              return 'linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%)';
+                            case 'llm_verification':
+                              return 'linear-gradient(135deg, #3b82f6 0%, #60a5fa 100%)';
+                            case 'human_review':
+                              return 'linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%)';
+                            case 'done':
+                              return 'linear-gradient(135deg, #10b981 0%, #34d399 100%)';
+                            case 'failed':
+                              return 'linear-gradient(135deg, #ef4444 0%, #f87171 100%)';
+                            default:
+                              return 'linear-gradient(135deg, #6b7280 0%, #9ca3af 100%)';
+                          }
+                        };
+                        
+                        return (
+                          <Box key={lang} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+                            <Chip
+                              label={getLanguageDisplayName(lang)}
+                              sx={{ 
+                                fontSize: '0.875rem',
+                                fontWeight: 600,
+                                background: getLanguageStatusGradient(langStatus),
+                                color: 'white',
+                                border: isFailedLang ? '2px solid #dc2626' : 'none',
+                                '&:hover': {
+                                  transform: 'scale(1.05)',
+                                },
+                                transition: 'transform 0.2s ease',
+                              }}
+                            />
+                            <Typography variant="caption" sx={{ 
+                              fontSize: '0.7rem',
+                              fontWeight: 600,
+                              color: isFailedLang ? '#dc2626' : '#64748b',
+                              textTransform: 'uppercase',
+                              textAlign: 'center'
+                            }}>
+                              {langStatus.replace('_', ' ')}
+                            </Typography>
+                            {isFailedLang && (
+                              <Box sx={{ 
+                                width: 6, 
+                                height: 6, 
+                                borderRadius: '50%', 
+                                backgroundColor: '#dc2626',
+                                animation: 'pulse 2s infinite'
+                              }} />
+                            )}
+                          </Box>
+                        );
+                      })}
                     </Box>
                   </CardContent>
                 </Card>

--- a/src/client/components/TaskDetailsModal.tsx
+++ b/src/client/components/TaskDetailsModal.tsx
@@ -40,8 +40,9 @@ import {
   Star as StarIcon,
   StarBorder as StarBorderIcon,
 } from '@mui/icons-material';
-import { TranslationTask } from '../../types';
+import { TranslationTask, LanguageTaskStatus } from '../../types';
 import { getLanguageDisplayName } from '../../utils/languageUtils';
+import TranslationTimeline from './TranslationTimeline';
 
 interface TaskDetailsModalProps {
   task: TranslationTask | null;
@@ -646,54 +647,173 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({ task, open, onClose
                 Translation Results
               </Typography>
               
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-                {task.result.translations.map((translation, index) => (
-                  <Card key={index} sx={{ overflow: 'visible' }}>
-                    <CardContent>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              {/* Translation Status Summary */}
+              <Card sx={{ mb: 3, background: 'linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%)', border: '1px solid #e2e8f0' }}>
+                <CardContent>
+                  <Typography variant="subtitle1" sx={{ color: '#1e293b', fontWeight: 600, mb: 2 }}>
+                    Status Overview
+                  </Typography>
+                  
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                    {task.result.translations.map((translation, index) => {
+                      const translationStatus = (translation.status || 'done') as LanguageTaskStatus;
+                      const isFailedTranslation = translationStatus === 'failed';
+                      
+                      return (
+                        <Box key={index} sx={{ 
+                          display: 'flex', 
+                          alignItems: 'center', 
+                          gap: 1,
+                          p: 1.5,
+                          background: isFailedTranslation 
+                            ? 'linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%)'
+                            : 'linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%)',
+                          border: `1px solid ${isFailedTranslation ? '#fecaca' : '#bbf7d0'}`,
+                          borderRadius: 2
+                        }}>
+                          <Typography variant="body2" sx={{ fontWeight: 600, color: '#1e293b' }}>
+                            {getLanguageDisplayName(translation.language)}:
+                          </Typography>
                           <Chip
-                            label={getLanguageDisplayName(translation.language)}
+                            label={translationStatus.replace('_', ' ').toUpperCase()}
+                            size="small"
                             sx={{
-                              background: getStatusGradient(),
+                              backgroundColor: isFailedTranslation ? '#ef4444' : '#10b981',
                               color: 'white',
                               fontWeight: 600,
-                              fontSize: '0.875rem',
+                              fontSize: '0.7rem'
                             }}
                           />
                           {translation.complianceScore && (
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                              <ScoreIcon sx={{ color: getComplianceColor(translation.complianceScore), fontSize: 20 }} />
-                              <Typography variant="body2" sx={{ fontWeight: 600, color: getComplianceColor(translation.complianceScore) }}>
-                                Compliance: {translation.complianceScore}%
-                              </Typography>
-                              <Rating
-                                value={getComplianceRating(translation.complianceScore)}
-                                readOnly
-                                size="small"
-                                sx={{
-                                  '& .MuiRating-iconFilled': {
-                                    color: getComplianceColor(translation.complianceScore),
-                                  },
-                                }}
-                              />
-                            </Box>
+                            <Typography variant="caption" sx={{ 
+                              color: isFailedTranslation ? '#dc2626' : '#059669',
+                              fontWeight: 600 
+                            }}>
+                              ({translation.complianceScore}%)
+                            </Typography>
                           )}
                         </Box>
-                        <IconButton
-                          onClick={() => copyToClipboard(translation.translatedText)}
-                          sx={{
-                            background: 'rgba(99, 102, 241, 0.1)',
-                            '&:hover': {
-                              background: 'rgba(99, 102, 241, 0.2)',
-                            },
-                          }}
-                        >
-                          <CopyIcon sx={{ color: '#6366f1' }} />
-                        </IconButton>
-                      </Box>
+                      );
+                    })}
+                  </Box>
+                  
+                  {/* Quick stats */}
+                  <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid #e2e8f0' }}>
+                    <Box sx={{ display: 'flex', gap: 4 }}>
+                      <Typography variant="body2" sx={{ color: '#059669', fontWeight: 600 }}>
+                        ✓ Successful: {task.result.translations.filter(t => t.status !== 'failed').length}
+                      </Typography>
+                      {task.result.translations.some(t => t.status === 'failed') && (
+                        <Typography variant="body2" sx={{ color: '#dc2626', fontWeight: 600 }}>
+                          ✗ Failed: {task.result.translations.filter(t => t.status === 'failed').length}
+                        </Typography>
+                      )}
+                    </Box>
+                  </Box>
+                </CardContent>
+              </Card>
+              
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                {task.result.translations.map((translation, index) => {
+                  const translationStatus = (translation.status || 'done') as LanguageTaskStatus;
+                  const isFailedTranslation = translationStatus === 'failed';
+                  
+                  return (
+                    <Card 
+                      key={index} 
+                      sx={{ 
+                        overflow: 'visible',
+                        border: isFailedTranslation ? '2px solid #ef4444' : '1px solid #e2e8f0',
+                        background: isFailedTranslation 
+                          ? 'linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%)' 
+                          : 'white'
+                      }}
+                    >
+                      <CardContent>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                            <Chip
+                              label={getLanguageDisplayName(translation.language)}
+                              sx={{
+                                background: isFailedTranslation 
+                                  ? 'linear-gradient(135deg, #ef4444 0%, #f87171 100%)'
+                                  : getStatusGradient(),
+                                color: 'white',
+                                fontWeight: 600,
+                                fontSize: '0.875rem',
+                              }}
+                            />
+                            {isFailedTranslation && (
+                              <Chip
+                                label="FAILED"
+                                size="small"
+                                sx={{
+                                  backgroundColor: '#dc2626',
+                                  color: 'white',
+                                  fontWeight: 700,
+                                  fontSize: '0.75rem',
+                                  animation: 'pulse 2s infinite'
+                                }}
+                              />
+                            )}
+                            {translation.complianceScore && (
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                <ScoreIcon sx={{ color: getComplianceColor(translation.complianceScore), fontSize: 20 }} />
+                                <Typography variant="body2" sx={{ fontWeight: 600, color: getComplianceColor(translation.complianceScore) }}>
+                                  Compliance: {translation.complianceScore}%
+                                </Typography>
+                                <Rating
+                                  value={getComplianceRating(translation.complianceScore)}
+                                  readOnly
+                                  size="small"
+                                  sx={{
+                                    '& .MuiRating-iconFilled': {
+                                      color: getComplianceColor(translation.complianceScore),
+                                    },
+                                  }}
+                                />
+                              </Box>
+                            )}
+                          </Box>
+                          <IconButton
+                            onClick={() => copyToClipboard(translation.translatedText)}
+                            sx={{
+                              background: 'rgba(99, 102, 241, 0.1)',
+                              '&:hover': {
+                                background: 'rgba(99, 102, 241, 0.2)',
+                              },
+                            }}
+                          >
+                            <CopyIcon sx={{ color: '#6366f1' }} />
+                          </IconButton>
+                        </Box>
 
-                      <Box
+                        {/* Translation Timeline */}
+                        <TranslationTimeline 
+                          currentStatus={translationStatus}
+                          language={getLanguageDisplayName(translation.language)}
+                        />
+                        
+                        {/* Alert box for failed translations */}
+                        {isFailedTranslation && (
+                          <Box sx={{
+                            p: 2,
+                            mt: 2,
+                            background: 'linear-gradient(135deg, #fee2e2 0%, #fecaca 100%)',
+                            border: '1px solid #f87171',
+                            borderRadius: 2,
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1
+                          }}>
+                            <ErrorIcon sx={{ color: '#dc2626', fontSize: 20 }} />
+                            <Typography variant="body2" sx={{ color: '#7f1d1d', fontWeight: 600 }}>
+                              This translation failed during processing. Please check the review notes below for details.
+                            </Typography>
+                          </Box>
+                        )}
+
+                        <Box
                         sx={{
                           p: 3,
                           background: 'linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%)',
@@ -732,9 +852,10 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({ task, open, onClose
                           </AccordionDetails>
                         </Accordion>
                       )}
-                    </CardContent>
-                  </Card>
-                ))}
+                      </CardContent>
+                    </Card>
+                  );
+                })}
               </Box>
 
               {task.result.processedAt && (

--- a/src/client/components/TranslationTimeline.test.tsx
+++ b/src/client/components/TranslationTimeline.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TranslationTimeline from './TranslationTimeline';
+import { LanguageTaskStatus } from '../../types';
+
+describe('TranslationTimeline', () => {
+  it('should render timeline for completed translation', () => {
+    render(
+      <TranslationTimeline 
+        currentStatus="done" 
+        language="French" 
+      />
+    );
+    
+    expect(screen.getByText('Translation Status for French')).toBeInTheDocument();
+    expect(screen.getByText('Status: Done')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('should render timeline for failed translation', () => {
+    render(
+      <TranslationTimeline 
+        currentStatus="failed" 
+        language="German" 
+      />
+    );
+    
+    expect(screen.getByText('Translation Status for German')).toBeInTheDocument();
+    expect(screen.getByText('Status: Failed')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('should render timeline for in-progress translation', () => {
+    render(
+      <TranslationTimeline 
+        currentStatus="llm_verification" 
+        language="Italian" 
+      />
+    );
+    
+    expect(screen.getByText('Translation Status for Italian')).toBeInTheDocument();
+    expect(screen.getByText('Status: LLM Check')).toBeInTheDocument();
+    expect(screen.getByText('LLM Check')).toBeInTheDocument();
+  });
+
+  it('should render all translation states', () => {
+    render(
+      <TranslationTimeline 
+        currentStatus="human_review" 
+        language="Spanish" 
+      />
+    );
+    
+    // All states should be present in the timeline
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Translating')).toBeInTheDocument();
+    expect(screen.getByText('LLM Check')).toBeInTheDocument();
+    expect(screen.getByText('Human Review')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/TranslationTimeline.tsx
+++ b/src/client/components/TranslationTimeline.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { Box, Typography, Chip } from '@mui/material';
+import {
+  HourglassEmpty as PendingIcon,
+  Translate as TranslatingIcon,
+  Psychology as VerificationIcon,
+  Person as ReviewIcon,
+  CheckCircle as DoneIcon,
+  Error as FailedIcon,
+} from '@mui/icons-material';
+import { LanguageTaskStatus } from '../../types';
+
+interface TranslationTimelineProps {
+  currentStatus: LanguageTaskStatus;
+  language: string;
+}
+
+const allStates: LanguageTaskStatus[] = [
+  'pending',
+  'translating', 
+  'llm_verification',  
+  'human_review',
+  'done'
+];
+
+const stateConfig = {
+  pending: {
+    label: 'Pending',
+    icon: PendingIcon,
+    color: '#ef4444',
+    bgColor: '#fef2f2',
+    borderColor: '#fecaca'
+  },
+  translating: {
+    label: 'Translating',
+    icon: TranslatingIcon,
+    color: '#f59e0b',
+    bgColor: '#fffbeb',
+    borderColor: '#fed7aa'
+  },
+  llm_verification: {
+    label: 'LLM Check',
+    icon: VerificationIcon,
+    color: '#3b82f6',
+    bgColor: '#eff6ff',
+    borderColor: '#bfdbfe'
+  },
+  human_review: {
+    label: 'Human Review',
+    icon: ReviewIcon,
+    color: '#8b5cf6',
+    bgColor: '#faf5ff',
+    borderColor: '#ddd6fe'
+  },
+  done: {
+    label: 'Done',
+    icon: DoneIcon,
+    color: '#10b981',
+    bgColor: '#f0fdf4',
+    borderColor: '#bbf7d0'
+  },
+  failed: {
+    label: 'Failed',
+    icon: FailedIcon,
+    color: '#ef4444',
+    bgColor: '#fef2f2',
+    borderColor: '#fecaca'
+  }
+};
+
+const TranslationTimeline: React.FC<TranslationTimelineProps> = ({ currentStatus, language }) => {
+  const getCurrentStateIndex = () => {
+    if (currentStatus === 'failed') {
+      // For failed status, we don't know exactly where it failed, so show it as the final state
+      return -1; // Special case for failed
+    }
+    return allStates.indexOf(currentStatus);
+  };
+
+  const currentIndex = getCurrentStateIndex();
+  const isFailed = currentStatus === 'failed';
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <Typography variant="caption" sx={{ display: 'block', mb: 1, fontWeight: 600, color: '#64748b' }}>
+        Translation Status for {language}
+      </Typography>
+      
+      <Box sx={{ 
+        display: 'flex', 
+        alignItems: 'center', 
+        gap: 1,
+        p: 2,
+        background: isFailed ? '#fef2f2' : '#f8fafc',
+        border: `1px solid ${isFailed ? '#fecaca' : '#e2e8f0'}`,
+        borderRadius: 2,
+        overflow: 'auto'
+      }}>
+        {/* Show progression through normal states */}
+        {allStates.map((state, index) => {
+          const config = stateConfig[state];
+          const IconComponent = config.icon;
+          const isCompleted = !isFailed && index < currentIndex;
+          const isCurrent = !isFailed && index === currentIndex;
+          const isUpcoming = !isFailed && index > currentIndex;
+          
+          return (
+            <React.Fragment key={state}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+                {/* State Icon */}
+                <Box sx={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: isCompleted 
+                    ? config.color 
+                    : isCurrent 
+                      ? config.color 
+                      : isUpcoming 
+                        ? '#e5e7eb' 
+                        : '#e5e7eb',
+                  border: `2px solid ${
+                    isCompleted || isCurrent ? config.color : '#d1d5db'
+                  }`,
+                  transition: 'all 0.3s ease'
+                }}>
+                  <IconComponent sx={{ 
+                    fontSize: 16, 
+                    color: isCompleted || isCurrent ? 'white' : '#9ca3af'
+                  }} />
+                </Box>
+                
+                {/* State Label */}
+                <Typography variant="caption" sx={{ 
+                  fontSize: '0.7rem',
+                  fontWeight: isCompleted || isCurrent ? 600 : 400,
+                  color: isCompleted || isCurrent ? config.color : '#9ca3af',
+                  textAlign: 'center',
+                  minWidth: '60px'
+                }}>
+                  {config.label}
+                </Typography>
+              </Box>
+              
+              {/* Connector Line */}
+              {index < allStates.length - 1 && (
+                <Box sx={{
+                  width: 24,
+                  height: 2,
+                  background: isCompleted 
+                    ? config.color 
+                    : '#e5e7eb',
+                  borderRadius: 1,
+                  transition: 'all 0.3s ease'
+                }} />
+              )}
+            </React.Fragment>
+          );
+        })}
+        
+        {/* Show failed status if applicable */}
+        {isFailed && (
+          <>
+            <Box sx={{
+              width: 24,
+              height: 2,
+              background: '#ef4444',
+              borderRadius: 1,
+            }} />
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+              <Box sx={{
+                width: 32,
+                height: 32,
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: '#ef4444',
+                border: '2px solid #ef4444',
+              }}>
+                <FailedIcon sx={{ fontSize: 16, color: 'white' }} />
+              </Box>
+              <Typography variant="caption" sx={{ 
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                color: '#ef4444',
+                textAlign: 'center',
+                minWidth: '60px'
+              }}>
+                Failed
+              </Typography>
+            </Box>
+          </>
+        )}
+      </Box>
+      
+      {/* Status chip for quick reference */}
+      <Box sx={{ mt: 1, display: 'flex', justifyContent: 'flex-end' }}>
+        <Chip
+          label={`Status: ${stateConfig[currentStatus].label}`}
+          size="small"
+          sx={{
+            backgroundColor: stateConfig[currentStatus].color,
+            color: 'white',
+            fontWeight: 600,
+            fontSize: '0.75rem'
+          }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default TranslationTimeline;

--- a/src/types.split-task.test.ts
+++ b/src/types.split-task.test.ts
@@ -1,0 +1,173 @@
+import {
+  TranslationTask,
+  getLanguageStatesForTask,
+  hasMultipleLanguageStates,
+  getLanguagesForStatus,
+  getTaskDisplayInfoForStatus,
+  LanguageTaskStatus
+} from './types';
+
+describe('Split Task Functionality', () => {
+  const mockTask: TranslationTask = {
+    id: 'task_123_abc',
+    status: 'human_review',
+    mediaArticle: {
+      text: 'Test article text',
+      title: 'Test Article'
+    },
+    editorialGuidelines: {
+      tone: 'professional'
+    },
+    destinationLanguages: ['fr', 'de', 'it'],
+    result: {
+      originalArticle: {
+        text: 'Test article text',
+        title: 'Test Article'
+      },
+      translations: [
+        {
+          language: 'fr',
+          translatedText: 'Article de test',
+          status: 'done',
+          complianceScore: 85
+        },
+        {
+          language: 'de',
+          translatedText: 'Test Artikel',
+          status: 'failed',
+          complianceScore: 45
+        },
+        {
+          language: 'it',
+          translatedText: 'Articolo di prova',
+          status: 'human_review',
+          complianceScore: 65
+        }
+      ],
+      processedAt: '2023-01-01T00:00:00Z'
+    },
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z',
+    progress: 80
+  };
+
+  describe('getLanguageStatesForTask', () => {
+    it('should return language states from translations when available', () => {
+      const states = getLanguageStatesForTask(mockTask);
+      
+      expect(states.get('fr')).toBe('done');
+      expect(states.get('de')).toBe('failed');
+      expect(states.get('it')).toBe('human_review');
+      expect(states.size).toBe(3);
+    });
+
+    it('should fall back to task status for languages without translations', () => {
+      const taskWithoutResult: TranslationTask = {
+        ...mockTask,
+        result: undefined
+      };
+      
+      const states = getLanguageStatesForTask(taskWithoutResult);
+      
+      expect(states.get('fr')).toBe('human_review');
+      expect(states.get('de')).toBe('human_review');
+      expect(states.get('it')).toBe('human_review');
+      expect(states.size).toBe(3);
+    });
+  });
+
+  describe('hasMultipleLanguageStates', () => {
+    it('should return true when languages have different states', () => {
+      expect(hasMultipleLanguageStates(mockTask)).toBe(true);
+    });
+
+    it('should return false when all languages have the same state', () => {
+      const taskWithSameStates: TranslationTask = {
+        ...mockTask,
+        result: {
+          ...mockTask.result!,
+          translations: [
+            { language: 'fr', translatedText: 'Test', status: 'done' },
+            { language: 'de', translatedText: 'Test', status: 'done' },
+            { language: 'it', translatedText: 'Test', status: 'done' }
+          ]
+        }
+      };
+      
+      expect(hasMultipleLanguageStates(taskWithSameStates)).toBe(false);
+    });
+  });
+
+  describe('getLanguagesForStatus', () => {
+    it('should return languages with the specified status', () => {
+      const doneLanguages = getLanguagesForStatus(mockTask, 'done');
+      const failedLanguages = getLanguagesForStatus(mockTask, 'failed');
+      const reviewLanguages = getLanguagesForStatus(mockTask, 'human_review');
+      
+      expect(doneLanguages).toEqual(['fr']);
+      expect(failedLanguages).toEqual(['de']);
+      expect(reviewLanguages).toEqual(['it']);
+    });
+
+    it('should return empty array when no languages match the status', () => {
+      const pendingLanguages = getLanguagesForStatus(mockTask, 'pending');
+      expect(pendingLanguages).toEqual([]);
+    });
+  });
+
+  describe('getTaskDisplayInfoForStatus', () => {
+    it('should return display info for status with matching languages', () => {
+      const displayInfo = getTaskDisplayInfoForStatus(mockTask, 'done');
+      
+      expect(displayInfo).not.toBeNull();
+      expect(displayInfo!.task).toBe(mockTask);
+      expect(displayInfo!.filteredLanguages).toEqual(['fr']);
+      expect(displayInfo!.isPartialDisplay).toBe(true);
+    });
+
+    it('should return null for status with no matching languages', () => {
+      const displayInfo = getTaskDisplayInfoForStatus(mockTask, 'pending');
+      expect(displayInfo).toBeNull();
+    });
+
+    it('should return display info with isPartialDisplay false for non-split tasks', () => {
+      const taskWithSameStates: TranslationTask = {
+        ...mockTask,
+        result: {
+          ...mockTask.result!,
+          translations: [
+            { language: 'fr', translatedText: 'Test', status: 'done' },
+            { language: 'de', translatedText: 'Test', status: 'done' },
+            { language: 'it', translatedText: 'Test', status: 'done' }
+          ]
+        }
+      };
+      
+      const displayInfo = getTaskDisplayInfoForStatus(taskWithSameStates, 'done');
+      
+      expect(displayInfo).not.toBeNull();
+      expect(displayInfo!.isPartialDisplay).toBe(false);
+      expect(displayInfo!.filteredLanguages).toEqual(['fr', 'de', 'it']);
+    });
+  });
+
+  describe('Split Task UI Logic', () => {
+    it('should generate multiple display infos for a split task across different statuses', () => {
+      const doneInfo = getTaskDisplayInfoForStatus(mockTask, 'done');
+      const failedInfo = getTaskDisplayInfoForStatus(mockTask, 'failed');
+      const reviewInfo = getTaskDisplayInfoForStatus(mockTask, 'human_review');
+      
+      expect(doneInfo).not.toBeNull();
+      expect(failedInfo).not.toBeNull();
+      expect(reviewInfo).not.toBeNull();
+      
+      expect(doneInfo!.filteredLanguages).toEqual(['fr']);
+      expect(failedInfo!.filteredLanguages).toEqual(['de']);
+      expect(reviewInfo!.filteredLanguages).toEqual(['it']);
+      
+      expect(doneInfo!.isPartialDisplay).toBe(true);
+      expect(failedInfo!.isPartialDisplay).toBe(true);
+      expect(reviewInfo!.isPartialDisplay).toBe(true);
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,47 @@ export const hasMultipleLanguageStates = (task: TranslationTask): boolean => {
   return uniqueStates.size > 1;
 };
 
+export interface TaskCardDisplayInfo {
+  task: TranslationTask;
+  filteredLanguages: string[];
+  isPartialDisplay: boolean;
+}
+
+export const getLanguagesForStatus = (
+  task: TranslationTask,
+  targetStatus: LanguageTaskStatus
+): string[] => {
+  const languageStates = getLanguageStatesForTask(task);
+  const languages: string[] = [];
+  
+  languageStates.forEach((status, language) => {
+    if (status === targetStatus) {
+      languages.push(language);
+    }
+  });
+  
+  return languages;
+};
+
+export const getTaskDisplayInfoForStatus = (
+  task: TranslationTask,
+  targetStatus: LanguageTaskStatus
+): TaskCardDisplayInfo | null => {
+  const languagesInStatus = getLanguagesForStatus(task, targetStatus);
+  
+  if (languagesInStatus.length === 0) {
+    return null;
+  }
+  
+  const isPartialDisplay = hasMultipleLanguageStates(task);
+  
+  return {
+    task,
+    filteredLanguages: languagesInStatus,
+    isPartialDisplay
+  };
+};
+
 // Prolific Filter Types
 export interface ProlificFilterChoice {
   [key: string]: string;


### PR DESCRIPTION
Right now, there is an attempt at having a UI based version of spilt tasks but it doesn't work as we'd like. So, let's re-implement.
In short, a task can have multiple languages. If it does, it's possible for the different languages to process at different rates and/or end up in different columns. We need to support this.
So as an example "Task 1" (so to speak) that has 3 languages of french, german and italian; the french language translates perfectly and ends up in 'done'. The german language hits an error and ends up in the error column. The italian language gets referred for human verification.
We need to show "Task 1" in ALL three columns, but instead of showing 3 languages on each card; instead it would only show the language that's actually in this state.
We *may* need to adjust the task structure to support this as we need to be able to track different states of different languages in a 'task'. But if you think this is necessary then check your plan with me before implementing.